### PR TITLE
Fix README command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to specify the directory.
 
 ```sh
 export JAGEOCODER_DB_DIR='/usr/local/share/jageocoder/db'
-python -m install-dictionary
+python -m jageocoder install-dictionary
 ```
 
 ## Update dictinary
@@ -76,7 +76,7 @@ To update the dictionary, run the `upgrade-dictionary` command.
 This process may take a long time.
 
 ```sh
-python -m upgrade-dictionary
+python -m jageocoder upgrade-dictionary
 ```
 
 ## Uninstall instructions

--- a/README_ja.md
+++ b/README_ja.md
@@ -60,7 +60,7 @@ python -m jageocoder get-db-dir
 
 ```sh
 export JAGEOCODER_DB_DIR='/usr/local/share/jageocoder/db'
-python -m install-dictionary
+python -m jageocoder install-dictionary
 ```
 
 ## 辞書の更新
@@ -77,7 +77,7 @@ python -m install-dictionary
 この処理には長時間かかることがあります。
 
 ```sh
-python -m upgrade-dictionary
+python -m jageocoder upgrade-dictionary
 ```
 
 ## アンインストール手順


### PR DESCRIPTION
Added `jageocoder` after `python -m` in README command example.

close #3 